### PR TITLE
Comparisons to types - PEP8 style guide

### DIFF
--- a/app/domain/triggers.py
+++ b/app/domain/triggers.py
@@ -14,7 +14,7 @@ class InstallEvent:
             "enforcement": enforcement.dict(),
         }
 
-        if type(success) != type(None):
+        if not isinstance(success, type(None)):
             event["success"] = success
 
         return event


### PR DESCRIPTION
* Code based on [PEP 8 Style Guide](https://www.python.org/dev/peps/pep-0008/)

> Object type comparisons should always use isinstance() instead of comparing types directly